### PR TITLE
Fix #2 Demo: display the size of json and nimn data

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
                     </div>
                     <div class="row">
                             <div class="col-md-4">
+                                    Length:<span id="lengthJson" class="badge badge-light" style="margin:5px">0</span>
                                     <textarea id="txtJson" name="json" rows="30" class="form-control" placeholder="Paste JSON here"></textarea>
                             </div>
                             <div class="col-md-4">
@@ -45,6 +46,7 @@
                             </div>                                         
                             <div class="col-md-4">
                                     <button id="makeitreadable" style="width: 100%;" class="btn btn-primary disabled" type="button">Make it Readable</button>
+                                    Length:<span id="lengthNimn" class="badge badge-light" style="margin:5px">0</span>
                                     <textarea id="txtNimn" name="nimn" rows="30" class="form-control" placeholder="Paste NIMN data here"></textarea>
                             </div>
             </div>
@@ -83,10 +85,14 @@
                             }
                             var result = nimnEncoder.encode(jObj);
                             $('#txtNimn').val(result);
+                            $("#lengthJson")[0].innerText= JSON.stringify(jObj).length;
+                            $("#lengthNimn")[0].innerText= result.length;
                             $("#makeitreadable").removeClass("disabled");
                         }catch(e){
                             $('#txtNimn').val(e);
                             $("#makeitreadable").addClass("disabled");
+                            $("#lengthNimn")[0].innerText = "#"
+                            $("#lengthJson")[0].innerText = "#"
                         }
                     });
 
@@ -120,15 +126,25 @@
                                 $('#txtJson').val(
                                     JSON.stringify(result,null,4)
                                 );
+                                $("#lengthNimn")[0].innerText= nimnData.length;
+                                $("#lengthJson")[0].innerText= JSON.stringify(result).length;
                             }
                             
                         }catch(e){
                             $('#txtJson').val(e);
+                            $("#lengthNimn")[0].innerText = "#"
+                            $("#lengthJson")[0].innerText = "#"
                         }
                     });
 
+                    $("#txtJson").on('input', function()
+                   {
+                      $('#lengthJson')[0].innerText = JSON.stringify(JSON.parse(this.value)).length; //This will fail until a proper json is entered
+                   });
+
                     $("#txtNimn").on('input', function()
                    {
+                        $('#lengthNimn')[0].innerText = this.value.length;
                         if( !this.value ) {
                             $("#makeitreadable").addClass("disabled");
                         }

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
                     </div>
                     <div class="row">
                             <div class="col-md-4">
-                                    Length:<span id="lengthJson" class="badge badge-light" style="margin:5px">0</span>
+                                    Length:<span id="lengthJson" class="badge" style="margin:5px">0</span>
                                     <textarea id="txtJson" name="json" rows="30" class="form-control" placeholder="Paste JSON here"></textarea>
                             </div>
                             <div class="col-md-4">
@@ -46,7 +46,7 @@
                             </div>                                         
                             <div class="col-md-4">
                                     <button id="makeitreadable" style="width: 100%;" class="btn btn-primary disabled" type="button">Make it Readable</button>
-                                    Length:<span id="lengthNimn" class="badge badge-light" style="margin:5px">0</span>
+                                    Length:<span id="lengthNimn" class="badge" style="margin:5px">0</span>
                                     <textarea id="txtNimn" name="nimn" rows="30" class="form-control" placeholder="Paste NIMN data here"></textarea>
                             </div>
             </div>
@@ -139,11 +139,19 @@
 
                     $("#txtJson").on('input', function()
                    {
-                      $('#lengthJson')[0].innerText = JSON.stringify(JSON.parse(this.value)).length; //This will fail until a proper json is entered
+                        try{
+                            if(this.value){
+                                $('#lengthJson')[0].innerText = JSON.stringify(JSON.parse(this.value)).length; //This will fail until a proper json is entered
+                            } else {
+                                $('#lengthJson')[0].innerText = 0;
+                            }
+                        }catch(e){
+                            $('#lengthJson')[0].innerText = "Invalid JSON"
+                        }
                    });
 
                     $("#txtNimn").on('input', function()
-                   {
+                   {   
                         $('#lengthNimn')[0].innerText = this.value.length;
                         if( !this.value ) {
                             $("#makeitreadable").addClass("disabled");


### PR DESCRIPTION
Length - When user provides an "Invalid JSON"

![image](https://user-images.githubusercontent.com/8343259/40165971-a642c384-59bd-11e8-93db-ae7dedb94f54.png)

Length - Proper JSON 

<img width="1372" alt="length - proper json and nimn data" src="https://user-images.githubusercontent.com/8343259/40166211-4ba8146e-59be-11e8-806c-3084014a0f09.png">

Length - During Exception

<img width="1362" alt="length - after exception" src="https://user-images.githubusercontent.com/8343259/40166220-5136fbe8-59be-11e8-9514-5722f09a0224.png">
